### PR TITLE
Fixes in French localization

### DIFF
--- a/Corona/Localization/fr.lproj/Localizable.strings
+++ b/Corona/Localization/fr.lproj/Localizable.strings
@@ -8,8 +8,8 @@
 */
 
 "case.confirmed" = "Confirmés";
-"case.active" = "Hospitalisés";
-"case.recovered" = "Réanimés";
+"case.active" = "Actifs";
+"case.recovered" = "Guéris";
 "case.deaths" = "Morts";
 "region.world" = "Monde";
 "chart.topCountries" = "Pays les plus touchés";


### PR DESCRIPTION
- "Active" was translated to "Hospitalisés" which means "at the hospital"
- "Recovered" was translated to "Réanimés", which means "Reanimated / Revived"