### PR TITLE
Ignore diactritics in search

### DIFF
--- a/Corona/Controller/RegionPanelController.swift
+++ b/Corona/Controller/RegionPanelController.swift
@@ -170,10 +170,10 @@ extension RegionPanelController: UISearchBarDelegate, UITableViewDelegate {
 	func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
 		var regions: [Region] = DataManager.instance.allRegions().sorted().reversed()
 
-		let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+		let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
 		if !query.isEmpty {
 			regions = regions.filter({ region in
-				region.localizedLongName.lowercased().contains(query)
+                region.localizedLongName.range(of: query, options: [.diacriticInsensitive, .caseInsensitive]) != nil
 			})
 		}
 

--- a/Corona/Controller/RegionPanelController.swift
+++ b/Corona/Controller/RegionPanelController.swift
@@ -173,7 +173,7 @@ extension RegionPanelController: UISearchBarDelegate, UITableViewDelegate {
 		let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
 		if !query.isEmpty {
 			regions = regions.filter({ region in
-                region.localizedLongName.range(of: query, options: [.diacriticInsensitive, .caseInsensitive]) != nil
+				region.localizedLongName.range(of: query, options: [.diacriticInsensitive, .caseInsensitive]) != nil
 			})
 		}
 


### PR DESCRIPTION
Changed search function to ignore diactritics in query.

For example in French it allows to search "États-Unis" (USA) without having to type the "É".

I do not know if it do not impact other langages negatively…



(well, as you understand, I'm bored… ;-)