### PR TITLE
Update value for change

### DIFF
--- a/Corona/Model/Change.swift
+++ b/Corona/Model/Change.swift
@@ -36,13 +36,13 @@ extension Change {
 		lastDeaths == 0 ? 0 :(Double(currentDeaths) / Double(lastDeaths) - 1) * 100
 	}
 
-    	public var newConfirmedString: String { newConfirmed > 0 ? "+\(newConfirmed.groupingFormatted)" : "-" }
+	public var newConfirmedString: String { newConfirmed > 0 ? "+\(newConfirmed.groupingFormatted)" : "-" }
 	public var newRecoveredString: String { currentRecovered == 0 ? "-" : "+\(newRecovered.groupingFormatted)" }
-    	public var newDeathsString: String { newDeaths > 0 ? "+\(newDeaths.groupingFormatted)" : "-" }
+	public var newDeathsString: String { newDeaths > 0 ? "+\(newDeaths.groupingFormatted)" : "-" }
 
-    	public var confirmedGrowthString: String { newConfirmed > 0 ? "↑\(confirmedGrowthPercent.kmFormatted)%" : "-" }
+	public var confirmedGrowthString: String { newConfirmed > 0 ? "↑\(confirmedGrowthPercent.kmFormatted)%" : "-" }
 	public var recoveredGrowthString: String { currentRecovered == 0 ? "-" : "↑\(recoveredGrowthPercent.kmFormatted)%" }
-    	public var deathsGrowthString: String { newDeaths > 0 ? "↑\(deathsGrowthPercent.kmFormatted)%" : "-" }
+	public var deathsGrowthString: String { newDeaths > 0 ? "↑\(deathsGrowthPercent.kmFormatted)%" : "-" }
 
 	public var isZero: Bool { newConfirmed == 0 && newRecovered == 0 && newDeaths == 0 }
 }

--- a/Corona/Model/Change.swift
+++ b/Corona/Model/Change.swift
@@ -36,13 +36,13 @@ extension Change {
 		lastDeaths == 0 ? 0 :(Double(currentDeaths) / Double(lastDeaths) - 1) * 100
 	}
 
-	public var newConfirmedString: String { "+\(newConfirmed.groupingFormatted)" }
+    	public var newConfirmedString: String { newConfirmed > 0 ? "+\(newConfirmed.groupingFormatted)" : "-" }
 	public var newRecoveredString: String { currentRecovered == 0 ? "-" : "+\(newRecovered.groupingFormatted)" }
-    public var newDeathsString: String { (lastDeaths < currentDeaths) ? "+\(newDeaths.groupingFormatted)" : "\(newDeaths.groupingFormatted)" }
+    	public var newDeathsString: String { newDeaths > 0 ? "+\(newDeaths.groupingFormatted)" : "-" }
 
-	public var confirmedGrowthString: String { "↑\(confirmedGrowthPercent.kmFormatted)%" }
+    	public var confirmedGrowthString: String { newConfirmed > 0 ? "↑\(confirmedGrowthPercent.kmFormatted)%" : "-" }
 	public var recoveredGrowthString: String { currentRecovered == 0 ? "-" : "↑\(recoveredGrowthPercent.kmFormatted)%" }
-    public var deathsGrowthString: String { (deathsGrowthPercent > 0) ? "↑\(deathsGrowthPercent.kmFormatted)%" : "↓\(fabs(deathsGrowthPercent).kmFormatted)%" }
+    	public var deathsGrowthString: String { newDeaths > 0 ? "↑\(deathsGrowthPercent.kmFormatted)%" : "-" }
 
 	public var isZero: Bool { newConfirmed == 0 && newRecovered == 0 && newDeaths == 0 }
 }

--- a/Corona/Model/Change.swift
+++ b/Corona/Model/Change.swift
@@ -38,11 +38,11 @@ extension Change {
 
 	public var newConfirmedString: String { "+\(newConfirmed.groupingFormatted)" }
 	public var newRecoveredString: String { currentRecovered == 0 ? "-" : "+\(newRecovered.groupingFormatted)" }
-	public var newDeathsString: String { "+\(newDeaths.groupingFormatted)" }
+    public var newDeathsString: String { (lastDeaths < currentDeaths) ? "+\(newDeaths.groupingFormatted)" : "\(newDeaths.groupingFormatted)" }
 
 	public var confirmedGrowthString: String { "↑\(confirmedGrowthPercent.kmFormatted)%" }
 	public var recoveredGrowthString: String { currentRecovered == 0 ? "-" : "↑\(recoveredGrowthPercent.kmFormatted)%" }
-	public var deathsGrowthString: String { "↑\(deathsGrowthPercent.kmFormatted)%" }
+    public var deathsGrowthString: String { (deathsGrowthPercent > 0) ? "↑\(deathsGrowthPercent.kmFormatted)%" : "↓\(fabs(deathsGrowthPercent).kmFormatted)%" }
 
 	public var isZero: Bool { newConfirmed == 0 && newRecovered == 0 && newDeaths == 0 }
 }


### PR DESCRIPTION
If you have a negative value upon dividing there is a negative value included in the change. Changing this value to `fabs()` if the division is greater than 0 will make it a positive value by using a ternary operation.

This pull request might address the issue. I am newer to iOS so if there is anything I can do to improve the PR, please let me know. The lines being addressed are [41](https://github.com/Yonodactyl/CoronaTracker/blob/38027562789382920ce9426194caca29458dde7c/Corona/Model/Change.swift#L41) & [45](https://github.com/Yonodactyl/CoronaTracker/blob/38027562789382920ce9426194caca29458dde7c/Corona/Model/Change.swift#L45).