### PR TITLE
Parse timeseries header dates and re-use them later

### DIFF
--- a/Corona/Service/JHURepoDataService.swift
+++ b/Corona/Service/JHURepoDataService.swift
@@ -151,7 +151,6 @@ public class JHURepoDataService: DataService {
 
 		let dateStrings = headers.dropFirst(4)
 		let dateValues = dateStrings.map { dateFormatter.date(from: $0) }
-		let mappedDates = Dictionary(uniqueKeysWithValues: zip(dateStrings, dateValues))
 
 		var regions: [Region] = []
 		for confirmedTimeSeries in confirmed {
@@ -160,8 +159,7 @@ public class JHURepoDataService: DataService {
 
 			var series: [Date: Statistic] = [:]
 			for column in confirmedTimeSeries.values.indices {
-				let dateString = dateStrings[dateStrings.startIndex + column]
-				if let dateEntry = mappedDates[dateString], let date = dateEntry {
+				if let date = dateValues[dateValues.startIndex + column] {
 					var recoveredCount = 0
 					if let recoveredTimeSeries = recoveredTimeSeries {
 						recoveredCount = recoveredTimeSeries.values[min(column, recoveredTimeSeries.values.count - 1)]

--- a/Corona/Service/JHURepoDataService.swift
+++ b/Corona/Service/JHURepoDataService.swift
@@ -150,6 +150,7 @@ public class JHURepoDataService: DataService {
 		dateFormatter.dateFormat = "M/d/yy"
 
 		let dateStrings = headers.dropFirst(4)
+		let dateValues = dateStrings.compactMap({ dateFormatter.date(from: $0) })
 
 		var regions: [Region] = []
 		for confirmedTimeSeries in confirmed {
@@ -158,23 +159,21 @@ public class JHURepoDataService: DataService {
 
 			var series: [Date: Statistic] = [:]
 			for column in confirmedTimeSeries.values.indices {
-				let dateString = dateStrings[dateStrings.startIndex + column]
-				if let date = dateFormatter.date(from: dateString) {
-					var recoveredCount = 0
-					if let recoveredTimeSeries = recoveredTimeSeries {
-						recoveredCount = recoveredTimeSeries.values[min(column, recoveredTimeSeries.values.count - 1)]
-					}
-					var deathCount = 0
-					if let deathsTimeSeries = deathsTimeSeries {
-						deathCount = deathsTimeSeries.values[min(column, deathsTimeSeries.values.count - 1)]
-					}
-					let stat = Statistic(
-						confirmedCount: confirmedTimeSeries.values[column],
-						recoveredCount: recoveredCount,
-						deathCount: deathCount
-					)
-					series[date] = stat
+				let date = dateValues[column]
+				var recoveredCount = 0
+				if let recoveredTimeSeries = recoveredTimeSeries {
+					recoveredCount = recoveredTimeSeries.values[min(column, recoveredTimeSeries.values.count - 1)]
 				}
+				var deathCount = 0
+				if let deathsTimeSeries = deathsTimeSeries {
+					deathCount = deathsTimeSeries.values[min(column, deathsTimeSeries.values.count - 1)]
+				}
+				let stat = Statistic(
+					confirmedCount: confirmedTimeSeries.values[column],
+					recoveredCount: recoveredCount,
+					deathCount: deathCount
+				)
+				series[date] = stat
 			}
 			let timeSeries = TimeSeries(series: series)
 


### PR DESCRIPTION
Reduce memory usage and increase performance by parsing the timeseries headers from JHU and reuse them later.